### PR TITLE
Add specific permissions to workflows under .github/workflows

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -19,6 +19,8 @@ on:
 
 jobs:
   noResponse:
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - uses: lee-dohm/no-response@v0.5.0

--- a/.github/workflows/publish-pip.yml
+++ b/.github/workflows/publish-pip.yml
@@ -4,6 +4,8 @@ on: push
 
 jobs:
   build-n-publish:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     if: startsWith(github.event.ref, 'refs/tags')
 

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -5,6 +5,8 @@ on: [push, pull_request]
 jobs:
   build:
 
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
This PR adds specific permissions to the existing workflows under .github/workflows. This is a feature that GitHub Actions supports: https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/

### Background

I have implemented a [GitHub App](https://github.com/apps/step-security) to automatically restrict permissions for the GITHUB_TOKEN in workflows. This is a security best practice as per the GitHub Actions [hardening guide](https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions). 

I am trying the App out on public repositories, by forking them, installing the App on the fork, and manually creating PRs with the fixed workflows. The App automatically fixes permissions when a PR is created that creates a new workflow, so feel free to [install it](https://github.com/apps/step-security) for future workflows, or try it out on other repos. 

I have manually reviewed the changes, and they do look good to me. If something looks off, please let me know. If you have feedback, would love to hear it. Thanks!