### PR TITLE
Make --outscale as optional

### DIFF
--- a/inference_realesrgan.py
+++ b/inference_realesrgan.py
@@ -21,7 +21,7 @@ def main():
         help=('Model names: RealESRGAN_x4plus | RealESRNet_x4plus | RealESRGAN_x4plus_anime_6B | RealESRGAN_x2plus | '
               'realesr-animevideov3'))
     parser.add_argument('-o', '--output', type=str, default='results', help='Output folder')
-    parser.add_argument('-s', '--outscale', type=float, default=4, help='The final upsampling scale of the image')
+    parser.add_argument('-s', '--outscale', type=float, help='The final upsampling scale of the image')
     parser.add_argument('--suffix', type=str, default='out', help='Suffix of the restored image')
     parser.add_argument('-t', '--tile', type=int, default=0, help='Tile size, 0 for no tile during testing')
     parser.add_argument('--tile_pad', type=int, default=10, help='Tile padding')
@@ -85,6 +85,7 @@ def main():
             arch='clean',
             channel_multiplier=2,
             bg_upsampler=upsampler)
+
     os.makedirs(args.output, exist_ok=True)
 
     if os.path.isfile(args.input):
@@ -105,8 +106,10 @@ def main():
         try:
             if args.face_enhance:
                 _, _, output = face_enhancer.enhance(img, has_aligned=False, only_center_face=False, paste_back=True)
-            else:
+            elif args.outscale:
                 output, _ = upsampler.enhance(img, outscale=args.outscale)
+            else:
+                output, _ = upsampler.enhance(img)
         except RuntimeError as error:
             print('Error', error)
             print('If you encounter CUDA out of memory, try to set --tile with a smaller number.')


### PR DESCRIPTION
In this commit, default value for --outscale is removed and handling of this removal is made between line 108 and 109.

This suggestion is based on my experience dealing with inference using this command:
`!python inference_realesrgan.py -n **RealESRGAN_x2plus** -i upload`

The inference are using general images, so I decided not to use `--outscale 3.5 --face_enhance` as demo shown in this [colab demo](https://colab.research.google.com/drive/1k2Zod6kSHEvraybHl50Lys0LerhyTMCo). The images used are scenery with low resolution. Hence, I think no need for me using `--face_enhance`. Also, I think I want to rely on model scale which x2 in this case. So, the `--outscale 3.5` is also removed. The inference is still running successfully. 

However, size of the images in result folder is upscale like other x4 models. When I reviewed the`inference_realesrgan.py`, I found out that this argument is set with default 4 ([line 24](https://github.com/xinntao/Real-ESRGAN/blob/e2db57602068a839b0f53df9efca7e57fa3c8a99/inference_realesrgan.py#L24)). I think this argument might not need for a default value but instead, using value based on the scale of model chosen, except if there is a need for it (by using `--outscale` during inference). So I removed the default value and rerun the inference.

However this time, the inference cannot make it. There is an error telling that, `outscale` value is needed. I re-reviewed the code and saw it used when `--face_enhance` is enabled ([line 84](https://github.com/xinntao/Real-ESRGAN/blob/e2db57602068a839b0f53df9efca7e57fa3c8a99/inference_realesrgan.py#L84)). In my case, this should not be an issue as I'm not not using it. Then, I found another use by `upsampler.enhance(img, outscale=args.outscale)` ([line 109](https://github.com/xinntao/Real-ESRGAN/blob/e2db57602068a839b0f53df9efca7e57fa3c8a99/inference_realesrgan.py#L109)).

Now I know why the inference could make it after I removed `--outscale 3.5` from my inference command. This line of code use default value of this argument. Once it is removed, no value is passed here. To solve this, one of way is I tried to locate the definition of `.enhance()`. I found it declared in utils.py located in Real-ESRGAN/realesrgan/. The class name `RealESRGANer` has method name `enhance` ([line 174](https://github.com/xinntao/Real-ESRGAN/blob/e2db57602068a839b0f53df9efca7e57fa3c8a99/realesrgan/utils.py#L174)). As written in the definition, the only required argument is `img` while the other are optional including `outscale`.

So, I suggest this small improvement that might fit my situation in `inference_realesrgan.py` file.

However, if my concept / understanding on this is wrong, I hope you could explained it so I will understand why the code is made like what it is now at the first place.

I hope this suggestion might help.
Thanks.