### PR TITLE
Give `inference_realesrgan.py` an entry point to use in other scripts

### DIFF
--- a/inference_realesrgan.py
+++ b/inference_realesrgan.py
@@ -1,11 +1,13 @@
 import argparse
+import cv2
 import glob
 import os
-import cv2
 
 from typing import Literal
+
 from basicsr.archs.rrdbnet_arch import RRDBNet
 from basicsr.utils.download_util import load_file_from_url
+
 from realesrgan import RealESRGANer
 from realesrgan.archs.srvgg_arch import SRVGGNetCompact
 

--- a/inference_realesrgan.py
+++ b/inference_realesrgan.py
@@ -1,9 +1,9 @@
 import argparse
 import glob
 import os
-from typing import Literal
-
 import cv2
+
+from typing import Literal
 from basicsr.archs.rrdbnet_arch import RRDBNet
 from basicsr.utils.download_util import load_file_from_url
 from realesrgan import RealESRGANer


### PR DESCRIPTION
Made it so its easier to use `inference_realesrgan.py` to be used in other scripts as `inference_realesrgan.run()`.

Not sure if this is useful to anybody else, but I needed it for one of my projects and sharing doesn't hurt.