### PR TITLE
Allow opus codec on mp4 videos

### DIFF
--- a/inference_realesrgan_video.py
+++ b/inference_realesrgan_video.py
@@ -151,7 +151,8 @@ class Writer:
                                  pix_fmt='yuv420p',
                                  vcodec='libx264',
                                  loglevel='error',
-                                 acodec='copy').overwrite_output().run_async(
+                                 acodec='copy',
+                                 strict='-2').overwrite_output().run_async(
                                      pipe_stdin=True, pipe_stdout=True, cmd=args.ffmpeg_bin))
         else:
             self.stream_writer = (


### PR DESCRIPTION
This version of ffmpeg throws an error, because opus audio codec in mp4s is still an experimental feature. The flag "strict='-2'" enables these kind of videos to still be processed.