### PR TITLE
README.md: added Holloway's Upscaler into Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ If you develop/use Real-ESRGAN in your projects, welcome to let me know.
 - NCNN-Android: [RealSR-NCNN-Android](https://github.com/tumuyan/RealSR-NCNN-Android) by [tumuyan](https://github.com/tumuyan)
 - VapourSynth: [vs-realesrgan](https://github.com/HolyWu/vs-realesrgan) by [HolyWu](https://github.com/HolyWu)
 - NCNN: [Real-ESRGAN-ncnn-vulkan](https://github.com/xinntao/Real-ESRGAN-ncnn-vulkan)
+- Video Upscaler: [Holloway's Upscaler](https://github.com/hollowaykeanho/Upscaler)
 
 &nbsp;&nbsp;&nbsp;&nbsp;**GUI**
 


### PR DESCRIPTION
I had recently glued the binaries products of Real-ESRGAN alongside its required models for a CLI-based upscaling tool that can work on image and video. Hence, to credit back, I'll add the project into the list of projects.

This patch adds Holloway's Upscaler into Projects in README.md.