### PR TITLE
Allowing Single GPU with ID 0 - Bug Fix

### DIFF
--- a/realesrgan/utils.py
+++ b/realesrgan/utils.py
@@ -45,7 +45,7 @@ class RealESRGANer():
         self.half = half
 
         # initialize model
-        if gpu_id:
+        if gpu_id and gpu_id != 0:
             self.device = torch.device(
                 f'cuda:{gpu_id}' if torch.cuda.is_available() else 'cpu') if device is None else device
         else:


### PR DESCRIPTION
This pull request addresses a bug that currently prevents the utilization of a single GPU with ID 0. Currently, the code includes a conditional check that inadvertently prevents the use of GPU 0 by not accounting for cases when the user explicitly passes GPU ID 0. The check is performed using the statement if gpu_id:, which unintentionally blocks GPU 0.

To resolve this issue, I propose modifying the check statement to if gpu_id and gpu_id != 0:. This adjustment ensures that the code will allow the use of GPU 0 while still appropriately handling cases where gpu_id is None.

This fix not only corrects the bug but also ensures compatibility with setups that involve a single GPU with ID 0. The modified condition will now consider both the non-null value of gpu_id and its non-equality to 0, thus enabling the correct behavior for single GPUs.