### PR TITLE
fix: set numpy version to avoid conflicts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 basicsr>=1.4.2
 facexlib>=0.2.5
 gfpgan>=1.3.5
-numpy
+numpy~=1.0
 opencv-python
 Pillow
 torch>=1.7


### PR DESCRIPTION
Set version to 1.x to avoid the use of numpy2.