### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,8 @@
-# Make sure user won't build real-esrgan image with the output folder
 outputs/
+weights/
+inputs/
+experiments/
+assets/
+.github/
+.vscode/
+options/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# Make sure user won't build real-esrgan image with the output folder
+outputs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN mkdir -p outputs
 RUN pip install ffmpeg-python
 
 # Install PyTorch
-RUN pip install torch==1.7.0+cu110 torchaudio==0.7.0 -f https://download.pytorch.org/whl/torch_stable.html
+RUN pip install torch==1.7.0+cu110 -f https://download.pytorch.org/whl/torch_stable.html
 
 # Install torchvision
 RUN pip install https://download.pytorch.org/whl/cu110/torchvision-0.8.0-cp38-cp38-linux_x86_64.whl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM python:3.8.20-bookworm
+
+# Fix: ImportError: libGL.so.1: cannot open shared object file: No such file or directory
+RUN apt-get update -y && apt-get -y install ffmpeg libsm6 libxext6
+
+# Copy files from source to the container
+COPY . /Real-ESRGAN
+
+# Set root at Real-ESRGAN
+WORKDIR /Real-ESRGAN
+
+# Create the outputs folder
+RUN mkdir -p outputs
+
+# Install pip ffmpeg
+RUN pip install ffmpeg-python
+
+# Install PyTorch
+RUN pip install torch==1.7.0+cu110 torchaudio==0.7.0 -f https://download.pytorch.org/whl/torch_stable.html
+
+# Install torchvision
+RUN pip install https://download.pytorch.org/whl/cu110/torchvision-0.8.0-cp38-cp38-linux_x86_64.whl
+
+# Install basicsr
+RUN pip install basicsr
+
+# Install facexlib
+RUN pip install facexlib
+
+# Install gfpgan
+RUN pip install gfpgan
+
+# Install all remain packages
+RUN pip install -r requirements.txt
+
+# Setup develop
+RUN python setup.py develop
+
+# Clean up all cached files
+RUN pip cache purge && apt-get clean autoclean && apt-get autoremove --yes && rm -rf /var/lib/{apt,dpkg,cache,log}/
+
+ENTRYPOINT [ "python" ]

--- a/README.md
+++ b/README.md
@@ -113,6 +113,42 @@ Other recommended projects:<br>
 
 ---
 
+### Installation with Docker
+
+*Note*: Only tested with Nvidia graphic card
+- https://docs.docker.com/get-started/get-docker/
+
+1. Clone repo
+
+    ```bash
+    git clone https://github.com/xinntao/Real-ESRGAN.git
+    cd Real-ESRGAN
+    ```
+
+1. Build Dockerfile
+
+    ```bash
+    docker build -f Dockerfile . -t real-esrgan
+    ```
+
+1. Run Real-ESRGAN inside Docker
+
+    *Note:* On Windows change `-v ./inputs:/Real-ESRGAN/inputs -v ./outputs:/Real-ESRGAN/outputs -v ./weights:/Real-ESRGAN/weights` to `-v .\inputs:/Real-ESRGAN/inputs -v .\outputs:/Real-ESRGAN/outputs -v .\weights:/Real-ESRGAN/weights`
+    ```bash
+    docker run -it --gpus all -v ./inputs:/Real-ESRGAN/inputs -v ./outputs:/Real-ESRGAN/outputs -v ./weights:/Real-ESRGAN/weights --rm real-esrgan inference_realesrgan.py --help
+    ```
+    ### Example
+    Inference a image
+    ```bash
+    docker run -it --gpus all -v ./inputs:/Real-ESRGAN/inputs -v ./outputs:/Real-ESRGAN/outputs -v ./weights:/Real-ESRGAN/weights --rm real-esrgan inference_realesrgan.py -i inputs/ADE_val_00000114.jpg -o outputs/ --ext png -n realesr-general-x4v3
+    ```
+    Inference a video
+    ```bash
+    docker run -it --gpus all -v ./inputs:/Real-ESRGAN/inputs -v ./outputs:/Real-ESRGAN/outputs -v ./weights:/Real-ESRGAN/weights --rm real-esrgan inference_realesrgan_video.py -i inputs/video/onepiece_demo.mp4 -o outputs/ -n realesr-animevideov3
+    ```
+
+---
+
 ## ⚡ Quick Inference
 
 There are usually three ways to inference Real-ESRGAN.


### PR DESCRIPTION
Added Docker support to the Real-ESRGAN project.

New files:
- Dockerfile: Defines the environment for running Real-ESRGAN in a Docker container.
- .dockerignore: Prevents unnecessary files from being included in the Docker image build.
Updated README:
- Added an installation guide for Docker in README.md to help users set up and run Real-ESRGAN in a containerized environment.
- *Note:* The installation guide in README_CN.md still needs to be added, but I am unable to provide the Chinese translation.

Next steps:
- A contributor familiar with Chinese can add the Docker installation section to README_CN.md.