### PR TITLE
Fix bug with limit version of torchvision because of basicsr and gfpgan.archs

### DIFF
--- a/inference_realesrgan.py
+++ b/inference_realesrgan.py
@@ -2,6 +2,24 @@ import argparse
 import cv2
 import glob
 import os
+
+import sys
+import types
+
+try:
+    # Check if `torchvision.transforms.functional_tensor` and `rgb_to_grayscale` are missing
+    from torchvision.transforms.functional_tensor import rgb_to_grayscale
+except ImportError:
+    # Import `rgb_to_grayscale` from `functional` if it’s missing in `functional_tensor`
+    from torchvision.transforms.functional import rgb_to_grayscale
+
+    # Create a module for `torchvision.transforms.functional_tensor`
+    functional_tensor = types.ModuleType("torchvision.transforms.functional_tensor")
+    functional_tensor.rgb_to_grayscale = rgb_to_grayscale
+
+    # Add this module to `sys.modules` so other imports can access it
+    sys.modules["torchvision.transforms.functional_tensor"] = functional_tensor
+    
 from basicsr.archs.rrdbnet_arch import RRDBNet
 from basicsr.utils.download_util import load_file_from_url
 

--- a/inference_realesrgan_video.py
+++ b/inference_realesrgan_video.py
@@ -7,6 +7,24 @@ import os
 import shutil
 import subprocess
 import torch
+
+import sys
+import types
+
+try:
+    # Check if `torchvision.transforms.functional_tensor` and `rgb_to_grayscale` are missing
+    from torchvision.transforms.functional_tensor import rgb_to_grayscale
+except ImportError:
+    # Import `rgb_to_grayscale` from `functional` if it’s missing in `functional_tensor`
+    from torchvision.transforms.functional import rgb_to_grayscale
+
+    # Create a module for `torchvision.transforms.functional_tensor`
+    functional_tensor = types.ModuleType("torchvision.transforms.functional_tensor")
+    functional_tensor.rgb_to_grayscale = rgb_to_grayscale
+
+    # Add this module to `sys.modules` so other imports can access it
+    sys.modules["torchvision.transforms.functional_tensor"] = functional_tensor
+    
 from basicsr.archs.rrdbnet_arch import RRDBNet
 from basicsr.utils.download_util import load_file_from_url
 from os import path as osp


### PR DESCRIPTION
Hi! I encountered an issue with compatibility in [issue #768](https://github.com/xinntao/Real-ESRGAN/issues/768) and wanted to share a solution that avoids limiting the torchvision version. Instead of enforcing a version constraint, we can make the code more flexible by dynamically adding any missing functions from torchvision.transforms.functional_tensor. This approach maintains compatibility across versions, allowing the code to benefit from performance and optimizations in newer versions of Torch and TorchVision as they become available.

Hope this helps streamline version handling in the project!