### PR TITLE
don't treat cv2.imread fail as fatal

### DIFF
--- a/inference_realesrgan.py
+++ b/inference_realesrgan.py
@@ -135,6 +135,10 @@ def main():
         print('Testing', idx, imgname)
 
         img = cv2.imread(path, cv2.IMREAD_UNCHANGED)
+        if img is None:
+            print(f"Error: failed to read image {path}. Skipping.")
+            continue
+
         if len(img.shape) == 3 and img.shape[2] == 4:
             img_mode = 'RGBA'
         else:


### PR DESCRIPTION
previously:
```
Traceback (most recent call last):
  File "/home/hans/projects/videofsck/Real-ESRGAN/inference_realesrgan.py", line 166, in <module>
    main()
  File "/home/hans/projects/videofsck/Real-ESRGAN/inference_realesrgan.py", line 138, in main
    if len(img.shape) == 3 and img.shape[2] == 4:
           ^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'shape'
```