### PR TITLE
ffmpeg-python is required

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Pillow
 torch>=1.7
 torchvision
 tqdm
+ffmpeg-python


### PR DESCRIPTION
and that's not obvious! there's at least 3 competing packages with incompatible apis:
ffmpeg
ffmpeg-python
python-ffmpeg

and this project happens to depend on ffmpeg-python (at least inference_realesrgan_video.py depends on ffmpeg-python)