### PR TITLE
fixed get_version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,9 +67,10 @@ version_info = ({})
 
 
 def get_version():
+    ns = {}
     with open(version_file, 'r') as f:
-        exec(compile(f.read(), version_file, 'exec'))
-    return locals()['__version__']
+        exec(compile(f.read(), version_file, 'exec'), ns)
+    return ns['__version__']
 
 
 def get_requirements(filename='requirements.txt'):


### PR DESCRIPTION
In Python 3.13, exec() inside a function no longer reliably updates the locals() dictionary, causing get_version() in setup.py to raise KeyError and return no version.
This patch fixes the issue by instantiating a dedicated namespace (ns = {}) for exec() and reading __version__ from that dictionary. This prevents mismanagement of local variables and ensures the correct version of Real-ESRGAN is returned consistently.