### PR TITLE
feat: add ArtImageHub web app to Projects that use Real-ESRGAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,11 @@ If you develop/use Real-ESRGAN in your projects, welcome to let me know.
 - [anime_upscaler](https://github.com/shangar21/anime_upscaler) by [shangar21](https://github.com/shangar21)
 - [Upscayl](https://github.com/upscayl/upscayl) by [Nayam Amarshe](https://github.com/NayamAmarshe) and [TGS963](https://github.com/TGS963)
 
+
+&nbsp;&nbsp;&nbsp;&nbsp;**Web Apps**
+
+- [ArtImageHub](https://artimagehub.com/old-photo-restoration) - AI old photo restoration web service (CodeFormer + GFPGAN + Real-ESRGAN) for restoring faded, scratched, and damaged family photos
+
 ## 🤗 Acknowledgement
 
 Thanks for all the contributors.


### PR DESCRIPTION
## Summary

Add **ArtImageHub** to the *Web Apps* sub-section under "Projects that use Real-ESRGAN".

**ArtImageHub** (https://artimagehub.com/old-photo-restoration) is a consumer web service for restoring old, faded, and damaged family photographs. It uses **Real-ESRGAN + CodeFormer + GFPGAN** in a single processing pipeline:

1. Damage repair (scratches, artifacts)
2. Face restoration (CodeFormer)
3. Image-wide enhancement (GFPGAN)
4. Upscaling (Real-ESRGAN)

Target use case: old printed family photos from the 1940s–1990s with physical degradation. Browser-based, no installation required.

Happy to provide any additional information.